### PR TITLE
Don't include the MSVC debug header if we aren't using MSVC

### DIFF
--- a/dumb/include/dumb.h
+++ b/dumb/include/dumb.h
@@ -25,8 +25,10 @@
 #include <stdio.h>
 
 #ifdef _DEBUG
+#ifdef _MSC_VER
 #define _CRTDBG_MAP_ALLOC
 #include <crtdbg.h>
+#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
The latest round of cmake changes made debug builds break on linux, this fixes that.
