### PR TITLE
Fix 2 places valgrind warns about unintialized memory being used

### DIFF
--- a/dumb/src/it/itrender.c
+++ b/dumb/src/it/itrender.c
@@ -328,6 +328,8 @@ static DUMB_IT_SIGRENDERER *dup_sigrenderer(DUMB_IT_SIGRENDERER *src, int n_chan
 	dst->time_left = src->time_left;
 	dst->sub_time_left = src->sub_time_left;
 
+	dst->ramp_style = src->ramp_style;
+
 	dst->click_remover = NULL;
 
 	dst->callbacks = callbacks;

--- a/dumb/src/it/readpsm.c
+++ b/dumb/src/it/readpsm.c
@@ -930,8 +930,10 @@ static DUMB_IT_SIGDATA *it_psm_load_sigdata(DUMBFILE *f, int * ver, int subsong)
 
 	sigdata->sample = malloc(sigdata->n_samples * sizeof(*sigdata->sample));
 	if (!sigdata->sample) goto error_ev;
-	for (n = 0; n < sigdata->n_samples; n++)
+	for (n = 0; n < sigdata->n_samples; n++) {
 		sigdata->sample[n].data = NULL;
+		sigdata->sample[n].flags = 0;
+	}
 
 	o = 0;
 	for (n = 0; n < n_chunks; n++) {


### PR DESCRIPTION
The 2 relevant valgrind warnings:

```
==2708== Conditional jump or move depends on uninitialised value(s)
==2708==    at 0x465B76: dumb_it_add_lpc (lpc.c:182)
==2708==    by 0x461043: init_sigrenderer (itrender.c:5289)
==2708==    by 0x4613B6: dumb_it_init_sigrenderer (itrender.c:5396)
==2708==    by 0x461EB6: dumb_it_build_checkpoints (itrender.c:5717)
==2708==    by 0x462111: dumb_it_do_initial_runthrough (itrender.c:5780)
==2708==    by 0x452C86: dumb_load_psm (loadpsm2.c:32)
==2708==    by 0x41DFA8: dumb_source_init (dumb_source.c:58)
==2708==    by 0x41C97D: music_play (music.c:75)
==2708==    by 0x431EC7: mainmenu_create (mainmenu.c:1414)
==2708==    by 0x4415E5: game_load_new (game_state.c:358)
==2708==    by 0x441CA6: game_state_dynamic_tick (game_state.c:543)
==2708==    by 0x44A835: engine_run (engine.c:251)
==2708==  Uninitialised value was created by a heap allocation
==2708==    at 0x4C28730: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2708==    by 0x47F8F1: it_psm_load_sigdata (readpsm.c:931)
==2708==    by 0x4804F5: dumb_read_psm_quick (readpsm.c:1263)
==2708==    by 0x452CCA: dumb_load_psm_quick (loadpsm.c:37)
==2708==    by 0x452C76: dumb_load_psm (loadpsm2.c:31)
==2708==    by 0x41DFA8: dumb_source_init (dumb_source.c:58)
==2708==    by 0x41C97D: music_play (music.c:75)
==2708==    by 0x431EC7: mainmenu_create (mainmenu.c:1414)
==2708==    by 0x4415E5: game_load_new (game_state.c:358)
==2708==    by 0x441CA6: game_state_dynamic_tick (game_state.c:543)
==2708==    by 0x44A835: engine_run (engine.c:251)
==2708==    by 0x44A214: main (main.c:186)
```

And

```
==2708== Conditional jump or move depends on uninitialised value(s)
==2708==    at 0x45C720: playing_volume_setup (itrender.c:3911)
==2708==    by 0x45C9C0: process_playing (itrender.c:3962)
==2708==    by 0x45D21C: process_all_playing (itrender.c:4155)
==2708==    by 0x45DE9E: process_tick (itrender.c:4452)
==2708==    by 0x4617BE: it_sigrenderer_get_samples (itrender.c:5508)
==2708==    by 0x462007: dumb_it_build_checkpoints (itrender.c:5748)
==2708==    by 0x462111: dumb_it_do_initial_runthrough (itrender.c:5780)
==2708==    by 0x452C86: dumb_load_psm (loadpsm2.c:32)
==2708==    by 0x41DFA8: dumb_source_init (dumb_source.c:58)
==2708==    by 0x41C97D: music_play (music.c:75)
==2708==    by 0x431EC7: mainmenu_create (mainmenu.c:1414)
==2708==    by 0x4415E5: game_load_new (game_state.c:358)
==2708==  Uninitialised value was created by a heap allocation
==2708==    at 0x4C28730: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==2708==    by 0x4538C9: dup_sigrenderer (itrender.c:286)
==2708==    by 0x461FAF: dumb_it_build_checkpoints (itrender.c:5741)
==2708==    by 0x462111: dumb_it_do_initial_runthrough (itrender.c:5780)
==2708==    by 0x452C86: dumb_load_psm (loadpsm2.c:32)
==2708==    by 0x41DFA8: dumb_source_init (dumb_source.c:58)
==2708==    by 0x41C97D: music_play (music.c:75)
==2708==    by 0x431EC7: mainmenu_create (mainmenu.c:1414)
==2708==    by 0x4415E5: game_load_new (game_state.c:358)
==2708==    by 0x441CA6: game_state_dynamic_tick (game_state.c:543)
==2708==    by 0x44A835: engine_run (engine.c:251)
==2708==    by 0x44A214: main (main.c:186)
```
