### PR TITLE
dumbout: Implement delay switch + cleanups

### DIFF
--- a/dumb/cmake/CMakeLists.txt
+++ b/dumb/cmake/CMakeLists.txt
@@ -119,7 +119,7 @@ set(EXAMPLE_TARGETS "")
 
 if(BUILD_EXAMPLES)
     add_executable(dumbout ../examples/dumbout.c)
-    target_link_libraries(dumbout ${ARGTABLE2_LIBRARY} dumb)
+    target_link_libraries(dumbout ${ARGTABLE2_LIBRARY} m dumb)
     include_directories(${ARGTABLE2_INCLUDE_DIR} "../examples/")
     set(EXAMPLE_TARGETS ${EXAMPLE_TARGETS} "dumbout")
 endif()

--- a/dumb/cmake/readme.txt
+++ b/dumb/cmake/readme.txt
@@ -27,4 +27,5 @@ Flags
 * CMAKE_INSTALL_PREFIX sets the installation path prefix
 * CMAKE_BUILD_TYPE sets the build type (eg. Release, Debug, RelWithDebInfo, MinSizeRel). Debug libraries will be named libdumbd, release libraries libdumb.
 * BUILD_SHARED_LIBS selects whether cmake should build dynamic or static library (On=shared, OFF=static)
+* BUILD_EXAMPLES selects example binaries. Note that example binaries require libargtable2 library. Enabled by default.
 * You may also need to tell cmake what kind of makefiles to create with the "-G" flag. Eg. for MSYS one would say something like `cmake -G "MSYS Makefiles" .`.


### PR DESCRIPTION
This adds the delay switch functionality in dumbout example that I previously forgot to add. Also does some cleanups.