### PR TITLE
Compatibility and usability improvements.

### DIFF
--- a/dumb/include/dumb.h
+++ b/dumb/include/dumb.h
@@ -228,6 +228,8 @@ DUH *read_duh(DUMBFILE *f);
 long duh_get_length(DUH *duh);
 
 const char *duh_get_tag(DUH *duh, const char *key);
+int duh_get_tag_iterator_size(DUH *duh);
+int duh_get_tag_iterator_get(DUH *duh, const char **key, const char **tag, int i);
 
 /* Signal Rendering Functions */
 
@@ -317,14 +319,40 @@ void duh_end_sigrenderer(DUH_SIGRENDERER *sigrenderer);
 
 /* DUH Rendering Functions */
 
-long duh_render(
+/* For packed integers: 8, 16, 24-bit wide. 
+ * Intermediary buffer sig_samples must be freed with destroy_sample_buffer()
+ * in the end of the rendering loop.
+ */
+long duh_render_int(
 	DUH_SIGRENDERER *sigrenderer,
+	sample_t ***sig_samples,
+	long *sig_samples_size,
 	int bits, int unsign,
 	float volume, float delta,
 	long size, void *sptr
 );
 
+/* For floats: 32, 64-bit wide.
+ * Intermediary buffer sig_samples must be freed with destroy_sample_buffer()
+ * in the end of the rendering loop.
+ */
+long duh_render_float(
+	DUH_SIGRENDERER *sigrenderer,
+	sample_t ***sig_samples,
+	long *sig_samples_size,
+	int bits,
+	float volume, float delta,
+	long size, void *sptr
+);
+
 #ifdef DUMB_DECLARE_DEPRECATED
+
+long duh_render(
+	DUH_SIGRENDERER *sigrenderer,
+	int bits, int unsign,
+	float volume, float delta,
+	long size, void *sptr
+) DUMB_DEPRECATED;
 
 long duh_render_signal(
 	DUH_SIGRENDERER *sigrenderer,

--- a/dumb/src/core/duhtag.c
+++ b/dumb/src/core/duhtag.c
@@ -36,3 +36,23 @@ const char *duh_get_tag(DUH *duh, const char *key)
 
 	return NULL;
 }
+
+
+
+int duh_get_tag_iterator_size(DUH *duh)
+{
+	return (duh && duh->tag ? duh->n_tags : 0);
+}
+
+
+int duh_get_tag_iterator_get(DUH *duh, const char **key, const char **tag, int i)
+{
+	ASSERT(key);
+	ASSERT(value);
+	if (!duh || !duh->tag || i >= duh->n_tags) return -1;
+
+	*key = duh->tag[i][0];
+	*tag = duh->tag[i][1];
+
+	return 0;
+}

--- a/dumb/src/helpers/resampler.c
+++ b/dumb/src/helpers/resampler.c
@@ -11,6 +11,8 @@
 #if TARGET_CPU_ARM || TARGET_CPU_ARM64
 #define RESAMPLER_NEON
 #endif
+#elif (defined(__arm__) && defined(__ARM_NEON__))
+#define RESAMPLER_NEON
 #endif
 #ifdef RESAMPLER_NEON
 #include <arm_neon.h>


### PR DESCRIPTION
* Reverted duh_get_tag_iterator_size(), duh_get_tag_iterator_get() API which allowed easy iteration over existing tags.
* New duh_render_float() API to render data to float and double types (it has modified behavior in comparison with duh_render() which allows to avoid buffer allocation on every subsequent call).
* Deprecated duh_render() in favor of duh_render_int() API.
* Added ARM NEON specific defines to allow NEON optimizations on non-Apple platforms as well.