### PR TITLE
Avoid exporting Vorbis helper API as it will conflict with Vorbis libs in a shared lib or executable if DUMB and Vorbis linked as static libs.

### DIFF
--- a/dumb/include/internal/lpc.h
+++ b/dumb/include/internal/lpc.h
@@ -18,12 +18,6 @@
 #ifndef _V_LPC_H_
 #define _V_LPC_H_
 
-/* simple linear scale LPC code */
-extern float vorbis_lpc_from_data(float *data,float *lpc,int n,int m);
-
-extern void vorbis_lpc_predict(float *coeff,float *prime,int m,
-                               float *data,long n);
-
 struct DUMB_IT_SIGDATA;
 extern void dumb_it_add_lpc(struct DUMB_IT_SIGDATA *sigdata);
 

--- a/dumb/src/helpers/lpc.c
+++ b/dumb/src/helpers/lpc.c
@@ -55,7 +55,7 @@ Carsten Bormann
 /* Input : n elements of time doamin data
    Output: m lpc coefficients, excitation energy */
 
-float vorbis_lpc_from_data(float *data,float *lpci,int n,int m){
+static float vorbis_lpc_from_data(float *data,float *lpci,int n,int m){
   double *aut=alloca(sizeof(*aut)*(m+1));
   double *lpc=alloca(sizeof(*lpc)*(m));
   double error;
@@ -127,7 +127,7 @@ float vorbis_lpc_from_data(float *data,float *lpci,int n,int m){
   return error;
 }
 
-void vorbis_lpc_predict(float *coeff,float *prime,int m,
+static void vorbis_lpc_predict(float *coeff,float *prime,int m,
                      float *data,long n){
 
   /* in: coeff[0...m-1] LPC coefficients


### PR DESCRIPTION
Make static and remove extern declaration from Vorbis helper API vorbis_lpc_from_data() and  vorbis_lpc_predict() as they will conflict in the project if DUMB is linked as static along with Vorbis static libraries in some other shared library or executable.