### PR TITLE
aldmb: Fix underlinking of dumb library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ if(BUILD_ALLEGRO4)
     add_library(aldmb ${ALLEGRO_SOURCES})
     list(APPEND DUMB_TARGETS aldmb)
     list(APPEND INSTALL_HEADERS include/aldumb.h)
-    target_link_libraries(aldmb ${ALLEGRO_LIBRARIES})
+    target_link_libraries(aldmb ${ALLEGRO_LIBRARIES} dumb)
 endif()
 
 if(BUILD_EXAMPLES)


### PR DESCRIPTION
Otherwise linking would fail with:
```
[ 22%] Linking C shared library libaldmb.so
/usr/bin/cmake -E cmake_link_script CMakeFiles/aldmb.dir/link.txt --verbose=1
/bin/cc  -fPIC -Wall -DDUMB_DECLARE_DEPRECATED -D_USE_SSE -msse -Wno-unused-variable -Wno-unused-but-set-variable -ffast-math -g -O2 -DNDEBUG -Wl,--as-needed -Wl,--no-undefined -Wl,-z,relro -Wl,-O1 -Wl,--build-id -Wl,--enable-new-dtags -shared -Wl,-soname,libaldmb.so -o libaldmb.so CMakeFiles/aldmb.dir/src/allegro/alplay.c.o CMakeFiles/aldmb.dir/src/allegro/datitq.c.o CMakeFiles/aldmb.dir/src/allegro/dats3m.c.o CMakeFiles/aldmb.dir/src/allegro/datxm.c.o CMakeFiles/aldmb.dir/src/allegro/datduh.c.o CMakeFiles/aldmb.dir/src/allegro/datmod.c.o CMakeFiles/aldmb.dir/src/allegro/dats3mq.c.o CMakeFiles/aldmb.dir/src/allegro/datxmq.c.o CMakeFiles/aldmb.dir/src/allegro/datit.c.o CMakeFiles/aldmb.dir/src/allegro/datmodq.c.o CMakeFiles/aldmb.dir/src/allegro/datunld.c.o CMakeFiles/aldmb.dir/src/allegro/packfile.c.o  -L/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/build -L/usr/lib64 -lalleg 
CMakeFiles/aldmb.dir/src/allegro/alplay.c.o: In function `al_start_duh':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/alplay.c:71: undefined reference to `duh_start_sigrenderer'
CMakeFiles/aldmb.dir/src/allegro/alplay.c.o: In function `al_stop_duh':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/alplay.c:91: undefined reference to `duh_end_sigrenderer'
CMakeFiles/aldmb.dir/src/allegro/alplay.c.o: In function `al_poll_duh':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/alplay.c:161: undefined reference to `duh_render'
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/alplay.c:173: undefined reference to `duh_sigrenderer_get_n_channels'
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/alplay.c:165: undefined reference to `duh_end_sigrenderer'
CMakeFiles/aldmb.dir/src/allegro/alplay.c.o: In function `al_duh_encapsulate_sigrenderer':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/alplay.c:205: undefined reference to `duh_sigrenderer_get_n_channels'
CMakeFiles/aldmb.dir/src/allegro/alplay.c.o: In function `al_duh_get_position':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/alplay.c:188: undefined reference to `duh_sigrenderer_get_position'
CMakeFiles/aldmb.dir/src/allegro/datitq.c.o: In function `dat_read_it_quick':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datitq.c:39: undefined reference to `dumb_read_it_quick'
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datitq.c:41: undefined reference to `dumbfile_close'
CMakeFiles/aldmb.dir/src/allegro/dats3m.c.o: In function `dat_read_s3m':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/dats3m.c:39: undefined reference to `dumb_read_s3m'
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/dats3m.c:41: undefined reference to `dumbfile_close'
CMakeFiles/aldmb.dir/src/allegro/datxm.c.o: In function `dat_read_xm':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datxm.c:39: undefined reference to `dumb_read_xm'
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datxm.c:41: undefined reference to `dumbfile_close'
CMakeFiles/aldmb.dir/src/allegro/datduh.c.o: In function `dat_read_duh':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datduh.c:39: undefined reference to `read_duh'
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datduh.c:41: undefined reference to `dumbfile_close'
CMakeFiles/aldmb.dir/src/allegro/datmod.c.o: In function `dat_read_mod':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datmod.c:39: undefined reference to `dumb_read_mod'
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datmod.c:41: undefined reference to `dumbfile_close'
CMakeFiles/aldmb.dir/src/allegro/dats3mq.c.o: In function `dat_read_s3m_quick':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/dats3mq.c:39: undefined reference to `dumb_read_s3m_quick'
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/dats3mq.c:41: undefined reference to `dumbfile_close'
CMakeFiles/aldmb.dir/src/allegro/datxmq.c.o: In function `dat_read_xm_quick':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datxmq.c:39: undefined reference to `dumb_read_xm_quick'
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datxmq.c:41: undefined reference to `dumbfile_close'
CMakeFiles/aldmb.dir/src/allegro/datit.c.o: In function `dat_read_it':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datit.c:39: undefined reference to `dumb_read_it'
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datit.c:41: undefined reference to `dumbfile_close'
CMakeFiles/aldmb.dir/src/allegro/datmodq.c.o: In function `dat_read_mod_quick':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datmodq.c:39: undefined reference to `dumb_read_mod_quick'
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datmodq.c:41: undefined reference to `dumbfile_close'
CMakeFiles/aldmb.dir/src/allegro/datunld.c.o: In function `_dat_unload_duh':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/datunld.c:29: undefined reference to `unload_duh'
CMakeFiles/aldmb.dir/src/allegro/packfile.c.o: In function `dumb_register_packfiles':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/packfile.c:119: undefined reference to `register_dumbfile_system'
CMakeFiles/aldmb.dir/src/allegro/packfile.c.o: In function `dumbfile_open_packfile':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/packfile.c:139: undefined reference to `dumbfile_open_ex'
CMakeFiles/aldmb.dir/src/allegro/packfile.c.o: In function `dumbfile_from_packfile':
/home/akien/Mageia/Checkout/dumb/BUILD/dumb-1.0+20170128/src/allegro/packfile.c:146: undefined reference to `dumbfile_open_ex'
collect2: error: ld returned 1 exit status
```