### PR TITLE
Add proper shared library versioning, set SOVERSION to 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.1)
 project(libdumb C)
 
+# Bump major (== soversion) on API breakages
+set(DUMB_VERSION_MAJOR 1)
+set(DUMB_VERSION_MINOR 0)
+set(DUMB_VERSION ${DUMB_VERSION_MAJOR}.${DUMB_VERSION_MINOR})
+
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-scripts)
 
 option(BUILD_EXAMPLES "Build example binaries" ON)
@@ -138,9 +143,14 @@ set(ALLEGRO_SOURCES
 
 add_library(dumb ${SOURCES})
 set_target_properties(dumb PROPERTIES DEBUG_POSTFIX d)
+set_target_properties(dumb PROPERTIES VERSION ${DUMB_VERSION})
+set_target_properties(dumb PROPERTIES SOVERSION ${DUMB_VERSION_MAJOR})
 
 if(BUILD_ALLEGRO4)
     add_library(aldmb ${ALLEGRO_SOURCES})
+    set_target_properties(aldmb PROPERTIES DEBUG_POSTFIX d)
+    set_target_properties(aldmb PROPERTIES VERSION ${DUMB_VERSION})
+    set_target_properties(aldmb PROPERTIES SOVERSION ${DUMB_VERSION_MAJOR})
     list(APPEND DUMB_TARGETS aldmb)
     list(APPEND INSTALL_HEADERS include/aldumb.h)
     target_link_libraries(aldmb ${ALLEGRO_LIBRARIES})


### PR DESCRIPTION
With this change, we get the conventional shared library structure:
```
$ ls -l
lrwxrwxrwx 1 akien akien     13 Jul 17 14:15 libaldmb.so -> libaldmb.so.1*
lrwxrwxrwx 1 akien akien     15 Jul 17 14:15 libaldmb.so.1 -> libaldmb.so.1.0*
-rwxr-xr-x 1 akien akien  15872 Jul 17 14:15 libaldmb.so.1.0*
lrwxrwxrwx 1 akien akien     12 Jul 17 14:15 libdumb.so -> libdumb.so.1*
lrwxrwxrwx 1 akien akien     14 Jul 17 14:15 libdumb.so.1 -> libdumb.so.1.0*
-rwxr-xr-x 1 akien akien 240824 Jul 17 14:15 libdumb.so.1.0*
$ objdump -x libdumb.so | grep SONAME
  SONAME               libdumb.so.1
```

Instead of (current state):
```
$ ls -l
-rwxr-xr-x 1 akien akien 15872 Jul 17 14:15 libaldmb.so
-rwxr-xr-x 1 akien akien 240824 Jul 17 14:15 libdumb.so
$ objdump -x libdumb.so | grep SONAME
  SONAME               libdumb.so
```

If/when you make changes to the API that would break compatibility with previous versions (i.e. downstream projects should rebuild their project against the numb dumb version), you would bump the major to force them doing so.