### PR TITLE
Make SSE instructions opt-out

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,16 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-scripts)
 
 option(BUILD_EXAMPLES "Build example binaries" ON)
 option(BUILD_ALLEGRO4 "Build Allegro4 support" ON)
+option(USE_SSE "Use SSE instructions" ON)
 
-set(CMAKE_C_FLAGS "-Wall -DDUMB_DECLARE_DEPRECATED -D_USE_SSE -msse -Wno-unused-variable -Wno-unused-but-set-variable")
+set(CMAKE_C_FLAGS "-Wall -DDUMB_DECLARE_DEPRECATED -Wno-unused-variable -Wno-unused-but-set-variable")
 set(CMAKE_C_FLAGS_DEBUG "-ggdb -DDEBUGMODE=1 -D_DEBUG")
 set(CMAKE_C_FLAGS_RELEASE "-ffast-math -O2 -DNDEBUG")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "-ffast-math -g -O2 -DNDEBUG")
 set(CMAKE_C_FLAGS_MINSIZEREL "-ffast-math -Os -DNDEBUG")
+if(USE_SSE)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_USE_SSE -msse")
+endif()
 
 link_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(include/)

--- a/src/helpers/resampler.c
+++ b/src/helpers/resampler.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #define _USE_MATH_DEFINES
 #include <math.h>
-#if (defined(_M_IX86) || defined(__i386__) || defined(_M_X64) || defined(__amd64__))
+#if defined(_USE_SSE) && (defined(_M_IX86) || defined(__i386__) || defined(_M_X64) || defined(__amd64__))
 #include <xmmintrin.h>
 #define RESAMPLER_SSE
 #endif


### PR DESCRIPTION
This way they can be disabled on platforms that do not support SSE,
e.g. some ARM boards.
Also fix missing _USE_SSE check.