### PR TITLE
Make gcc -wmisleading-indentation happy

### DIFF
--- a/src/it/itread.c
+++ b/src/it/itread.c
@@ -623,8 +623,8 @@ long _dumb_it_read_sample_data_adpcm4(IT_SAMPLE *sample, DUMBFILE *f)
 	long n, len, delta;
 	signed char * ptr, * end;
 	signed char compression_table[16];
-    if (dumbfile_getnc((char *)compression_table, 16, f) != 16)
-        return -1;
+	if (dumbfile_getnc((char *)compression_table, 16, f) != 16)
+		return -1;
 	ptr = (signed char *) sample->data;
 	delta = 0;
 

--- a/src/it/readmod.c
+++ b/src/it/readmod.c
@@ -283,15 +283,15 @@ static DUMB_IT_SIGDATA *it_mod_load_sigdata(DUMBFILE *f, int restrict_)
 	int i;
 	unsigned long fft;
 
-    if ( dumbfile_seek(f, MOD_FFT_OFFSET, DFS_SEEK_SET) )
-        return NULL;
+	if ( dumbfile_seek(f, MOD_FFT_OFFSET, DFS_SEEK_SET) )
+		return NULL;
 
-    fft = dumbfile_mgetl(f);
-    if (dumbfile_error(f))
-        return NULL;
+	fft = dumbfile_mgetl(f);
+	if (dumbfile_error(f))
+		return NULL;
 
-    if ( dumbfile_seek(f, 0, DFS_SEEK_SET) )
-        return NULL;
+	if ( dumbfile_seek(f, 0, DFS_SEEK_SET) )
+		return NULL;
 
 	sigdata = malloc(sizeof(*sigdata));
 	if (!sigdata) {

--- a/src/it/readxm.c
+++ b/src/it/readxm.c
@@ -897,15 +897,15 @@ static DUMB_IT_SIGDATA *it_xm_load_sigdata(DUMBFILE *f, int * version)
 	if (sigdata->speed == 0) sigdata->speed = 6; // Should we? What about tempo?
 	sigdata->tempo            = dumbfile_igetw(f);
 
-    // FT2 always clips restart position against the song length
-    if (sigdata->restart_position > sigdata->n_orders)
-        sigdata->restart_position = sigdata->n_orders;
-    // And FT2 starts playback on order 0, regardless of length,
-    // and only checks if the next order is greater than or equal
-    // to this, not the current pattern. Work around this with
-    // DUMB's playback core by overriding a zero length with one.
-    if (sigdata->n_orders == 0)
-        sigdata->n_orders = 1;
+	// FT2 always clips restart position against the song length
+	if (sigdata->restart_position > sigdata->n_orders)
+		sigdata->restart_position = sigdata->n_orders;
+	// And FT2 starts playback on order 0, regardless of length,
+	// and only checks if the next order is greater than or equal
+	// to this, not the current pattern. Work around this with
+	// DUMB's playback core by overriding a zero length with one.
+	if (sigdata->n_orders == 0)
+		sigdata->n_orders = 1;
 
 	/* sanity checks */
 	// XXX


### PR DESCRIPTION
This just uses tabs for indentation instead of spaces in some places, and makes GCC's warnings happy again.