### PR TITLE
Remove most deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,14 @@
 * Audio playback quality improvements for STM
 * Added support for FEST MOD files
 * Default resampling quality is now cubic
-* Allegro4 support
+* Allegro 4 support
 * New dumbplay, dumbout examples
 * Multiple cmake fixes
-* duh_render() deprecated. Instead, there are new duh_render_float() 
-  and duh_render_int() API functions.
+* Deprecated `duh_render()`, use `duh_render_float()` and `duh_render_int()`
+* Removed API deprecated since 0.9.3, see the
+    [DUMB 0.9.3 deprecation reference](http://dumb.sourceforge.net/index.php?page=docs&doc=deprec)
 
-## v1.0.0, released 17 January 2017
+## v1.0.0, released 17 January 2015
 
 * Support newer compilers
 * Better audio playback quality

--- a/include/aldumb.h
+++ b/include/aldumb.h
@@ -78,17 +78,6 @@ DUH_SIGRENDERER *al_duh_get_sigrenderer(AL_DUH_PLAYER *dp);
 /* IMPORTANT: This function will return NULL if the music has ended. */
 DUH_SIGRENDERER *al_duh_decompose_to_sigrenderer(AL_DUH_PLAYER *dp);
 
-#ifdef DUMB_DECLARE_DEPRECATED
-
-AL_DUH_PLAYER *al_duh_encapsulate_renderer(DUH_SIGRENDERER *dr, float volume, long bufsize, int freq) DUMB_DEPRECATED;
-DUH_SIGRENDERER *al_duh_get_renderer(AL_DUH_PLAYER *dp) DUMB_DEPRECATED;
-DUH_SIGRENDERER *al_duh_decompose_to_renderer(AL_DUH_PLAYER *dp) DUMB_DEPRECATED;
-/* Replace 'renderer' with 'sigrenderer' in each case where you called one of
- * these functions.
- */
-
-#endif
-
 
 #ifdef __cplusplus
 	}

--- a/include/dumb.h
+++ b/include/dumb.h
@@ -46,36 +46,6 @@
 
 #define DUMB_NAME "DUMB v" DUMB_VERSION_STR
 
-#define DUMB_YEAR  2015
-#define DUMB_MONTH 1
-#define DUMB_DAY   17
-
-#define DUMB_YEAR_STR2  "15"
-#define DUMB_YEAR_STR4  "2015"
-#define DUMB_MONTH_STR1 "1"
-#define DUMB_DAY_STR1   "17"
-
-#if DUMB_MONTH < 10
-#define DUMB_MONTH_STR2 "0" DUMB_MONTH_STR1
-#else
-#define DUMB_MONTH_STR2 DUMB_MONTH_STR1
-#endif
-
-#if DUMB_DAY < 10
-#define DUMB_DAY_STR2 "0" DUMB_DAY_STR1
-#else
-#define DUMB_DAY_STR2 DUMB_DAY_STR1
-#endif
-
-
-/* WARNING: The month and day were inadvertently swapped in the v0.8 release.
- *          Please do not compare this constant against any date in 2002. In
- *          any case, DUMB_VERSION is probably more useful for this purpose.
- */
-#define DUMB_DATE (DUMB_YEAR*10000 + DUMB_MONTH*100 + DUMB_DAY)
-
-#define DUMB_DATE_STR DUMB_DAY_STR1 "." DUMB_MONTH_STR1 "." DUMB_YEAR_STR4
-
 
 #ifdef DEBUGMODE
 
@@ -97,15 +67,13 @@
 #define TRACE 1 ? (void)0 : (void)printf
 #endif
 
-#endif
+#endif // DEBUGMODE
 
 
 #define DUMB_ID(a,b,c,d) (((unsigned int)(a) << 24) | \
                           ((unsigned int)(b) << 16) | \
                           ((unsigned int)(c) <<  8) | \
                           ((unsigned int)(d)      ))
-
-
 
 #ifndef LONG_LONG
 #if defined __GNUC__ || defined __INTEL_COMPILER || defined __MWERKS__
@@ -307,7 +275,7 @@ void duh_end_sigrenderer(DUH_SIGRENDERER *sigrenderer);
 
 /* DUH Rendering Functions */
 
-/* For packed integers: 8, 16, 24-bit wide. 
+/* For packed integers: 8, 16, 24-bit wide.
  * Intermediary buffer sig_samples must be freed with destroy_sample_buffer()
  * in the end of the rendering loop.
  */

--- a/include/dumb.h
+++ b/include/dumb.h
@@ -193,50 +193,6 @@ typedef struct DUH_SIGRENDERER DUH_SIGRENDERER;
 
 DUH_SIGRENDERER *duh_start_sigrenderer(DUH *duh, int sig, int n_channels, long pos);
 
-#ifdef DUMB_DECLARE_DEPRECATED
-typedef void (*DUH_SIGRENDERER_CALLBACK)(void *data, sample_t **samples, int n_channels, long length);
-/* This is deprecated, but is not marked as such because GCC tends to
- * complain spuriously when the typedef is used later. See comments below.
- */
-
-void duh_sigrenderer_set_callback(
-	DUH_SIGRENDERER *sigrenderer,
-	DUH_SIGRENDERER_CALLBACK callback, void *data
-) DUMB_DEPRECATED;
-/* The 'callback' argument's type has changed for const-correctness. See the
- * DUH_SIGRENDERER_CALLBACK definition just above. Also note that the samples
- * in the buffer are now 256 times as large; the normal range is -0x800000 to
- * 0x7FFFFF. The function has been renamed partly because its functionality
- * has changed slightly and partly so that its name is more meaningful. The
- * new one is duh_sigrenderer_set_analyser_callback(), and the typedef for
- * the function pointer has also changed, from DUH_SIGRENDERER_CALLBACK to
- * DUH_SIGRENDERER_ANALYSER_CALLBACK. (If you wanted to use this callback to
- * apply a DSP effect, don't worry; there is a better way of doing this. It
- * is undocumented, so contact me and I shall try to help. Contact details
- * are in readme.txt.)
- */
-
-typedef void (*DUH_SIGRENDERER_ANALYSER_CALLBACK)(void *data, const sample_t *const *samples, int n_channels, long length);
-/* This is deprecated, but is not marked as such because GCC tends to
- * complain spuriously when the typedef is used later. See comments below.
- */
-
-void duh_sigrenderer_set_analyser_callback(
-	DUH_SIGRENDERER *sigrenderer,
-	DUH_SIGRENDERER_ANALYSER_CALLBACK callback, void *data
-) DUMB_DEPRECATED;
-/* This is deprecated because the meaning of the 'samples' parameter in the
- * callback needed to change. For stereo applications, the array used to be
- * indexed with samples[channel][pos]. It is now indexed with
- * samples[0][pos*2+channel]. Mono sample data are still indexed with
- * samples[0][pos]. The array is still 2D because samples will probably only
- * ever be interleaved in twos. In order to fix your code, adapt it to the
- * new sample layout and then call
- * duh_sigrenderer_set_sample_analyser_callback below instead of this
- * function.
- */
-#endif
-
 typedef void (*DUH_SIGRENDERER_SAMPLE_ANALYSER_CALLBACK)(void *data, const sample_t *const *samples, int n_channels, long length);
 
 void duh_sigrenderer_set_sample_analyser_callback(
@@ -248,19 +204,6 @@ int duh_sigrenderer_get_n_channels(DUH_SIGRENDERER *sigrenderer);
 long duh_sigrenderer_get_position(DUH_SIGRENDERER *sigrenderer);
 
 void duh_sigrenderer_set_sigparam(DUH_SIGRENDERER *sigrenderer, unsigned char id, long value);
-
-#ifdef DUMB_DECLARE_DEPRECATED
-long duh_sigrenderer_get_samples(
-	DUH_SIGRENDERER *sigrenderer,
-	float volume, float delta,
-	long size, sample_t **samples
-) DUMB_DEPRECATED;
-/* The sample format has changed, so if you were using this function,
- * you should switch to duh_sigrenderer_generate_samples() and change
- * how you interpret the samples array. See the comments for
- * duh_sigrenderer_set_analyser_callback().
- */
-#endif
 
 long duh_sigrenderer_generate_samples(
 	DUH_SIGRENDERER *sigrenderer,
@@ -303,44 +246,13 @@ long duh_render_float(
 
 #ifdef DUMB_DECLARE_DEPRECATED
 
+/* DEPRECATED since 2.0.0. Please use duh_render_int or duh_render_float. */
 long duh_render(
 	DUH_SIGRENDERER *sigrenderer,
 	int bits, int unsign,
 	float volume, float delta,
 	long size, void *sptr
 ) DUMB_DEPRECATED;
-
-long duh_render_signal(
-	DUH_SIGRENDERER *sigrenderer,
-	float volume, float delta,
-	long size, sample_t **samples
-) DUMB_DEPRECATED;
-/* Please use duh_sigrenderer_generate_samples(), and see the
- * comments for the deprecated duh_sigrenderer_get_samples() too.
- */
-
-typedef DUH_SIGRENDERER DUH_RENDERER DUMB_DEPRECATED;
-/* Please use DUH_SIGRENDERER instead of DUH_RENDERER. */
-
-DUH_SIGRENDERER *duh_start_renderer(DUH *duh, int n_channels, long pos) DUMB_DEPRECATED;
-/* Please use duh_start_sigrenderer() instead. Pass 0 for 'sig'. */
-
-int duh_renderer_get_n_channels(DUH_SIGRENDERER *dr) DUMB_DEPRECATED;
-long duh_renderer_get_position(DUH_SIGRENDERER *dr) DUMB_DEPRECATED;
-/* Please use the duh_sigrenderer_*() equivalents of these two functions. */
-
-void duh_end_renderer(DUH_SIGRENDERER *dr) DUMB_DEPRECATED;
-/* Please use duh_end_sigrenderer() instead. */
-
-DUH_SIGRENDERER *duh_renderer_encapsulate_sigrenderer(DUH_SIGRENDERER *sigrenderer) DUMB_DEPRECATED;
-DUH_SIGRENDERER *duh_renderer_get_sigrenderer(DUH_SIGRENDERER *dr) DUMB_DEPRECATED;
-DUH_SIGRENDERER *duh_renderer_decompose_to_sigrenderer(DUH_SIGRENDERER *dr) DUMB_DEPRECATED;
-/* These functions have become no-ops that just return the parameter.
- * So, for instance, replace
- *   duh_renderer_encapsulate_sigrenderer(my_sigrenderer)
- * with
- *   my_sigrenderer
- */
 
 #endif
 
@@ -626,13 +538,6 @@ sigrenderer_t *duh_get_raw_sigrenderer(DUH_SIGRENDERER *sigrenderer, long type);
 
 /* Sample Buffer Allocation Helpers */
 
-#ifdef DUMB_DECLARE_DEPRECATED
-sample_t **create_sample_buffer(int n_channels, long length) DUMB_DEPRECATED;
-/* DUMB has been changed to interleave stereo samples. Use
- * allocate_sample_buffer() instead, and see the comments for
- * duh_sigrenderer_set_analyser_callback().
- */
-#endif
 sample_t **allocate_sample_buffer(int n_channels, long length);
 void destroy_sample_buffer(sample_t **samples);
 

--- a/src/allegro/alplay.c
+++ b/src/allegro/alplay.c
@@ -251,27 +251,3 @@ DUH_SIGRENDERER *al_duh_decompose_to_sigrenderer(AL_DUH_PLAYER *dp)
 	}
 	return NULL;
 }
-
-
-
-/* DEPRECATED */
-AL_DUH_PLAYER *al_duh_encapsulate_renderer(DUH_SIGRENDERER *dr, float volume, long bufsize, int freq)
-{
-	return al_duh_encapsulate_sigrenderer(dr, volume, bufsize, freq);
-}
-
-
-
-/* DEPRECATED */
-DUH_SIGRENDERER *al_duh_get_renderer(AL_DUH_PLAYER *dp)
-{
-	return al_duh_get_sigrenderer(dp);
-}
-
-
-
-/* DEPRECATED */
-DUH_SIGRENDERER *al_duh_decompose_to_renderer(AL_DUH_PLAYER *dp)
-{
-	return al_duh_decompose_to_sigrenderer(dp);
-}

--- a/src/core/rendduh.c
+++ b/src/core/rendduh.c
@@ -87,13 +87,8 @@
 }
 
 
-/* DEPRECATED */
-DUH_SIGRENDERER *duh_start_renderer(DUH *duh, int n_channels, long pos)
-{
-	return duh_start_sigrenderer(duh, 0, n_channels, pos);
-}
 
-
+/* This is the only deprecated function in 2.0.0. */
 /* DEPRECATED */
 long duh_render(
 	DUH_SIGRENDERER *sigrenderer,
@@ -200,7 +195,7 @@ long duh_render_int(
 	if (bits == 24) {
 		long i = 0;
 		ASSERT(unsign == 0);
-		
+
 		for (n = 0; n < size * n_channels; n++, i += 3) {
 			CONVERT24(sampptr[0][n], i);
 		}
@@ -278,54 +273,7 @@ long duh_render_float(
 		for (n = 0; n < size * n_channels; n++) {
 			CONVERT32F(sampptr[0][n], n);
 		}
-	} 
+	}
 
 	return size;
-}
-
-
-/* DEPRECATED */
-int duh_renderer_get_n_channels(DUH_SIGRENDERER *dr)
-{
-	return duh_sigrenderer_get_n_channels(dr);
-}
-
-
-
-/* DEPRECATED */
-long duh_renderer_get_position(DUH_SIGRENDERER *dr)
-{
-	return duh_sigrenderer_get_position(dr);
-}
-
-
-
-/* DEPRECATED */
-void duh_end_renderer(DUH_SIGRENDERER *dr)
-{
-	duh_end_sigrenderer(dr);
-}
-
-
-
-/* DEPRECATED */
-DUH_SIGRENDERER *duh_renderer_encapsulate_sigrenderer(DUH_SIGRENDERER *sigrenderer)
-{
-	return sigrenderer;
-}
-
-
-
-/* DEPRECATED */
-DUH_SIGRENDERER *duh_renderer_get_sigrenderer(DUH_SIGRENDERER *dr)
-{
-	return dr;
-}
-
-
-
-/* DEPRECATED */
-DUH_SIGRENDERER *duh_renderer_decompose_to_sigrenderer(DUH_SIGRENDERER *dr)
-{
-	return dr;
 }

--- a/src/core/rendsig.c
+++ b/src/core/rendsig.c
@@ -90,37 +90,6 @@ DUH_SIGRENDERER *duh_start_sigrenderer(DUH *duh, int sig, int n_channels, long p
 
 
 
-#include <stdio.h>
-void duh_sigrenderer_set_callback(
-	DUH_SIGRENDERER *sigrenderer,
-	DUH_SIGRENDERER_CALLBACK callback, void *data
-)
-{
-	(void)sigrenderer;
-	(void)callback;
-	(void)data;
-	/*fprintf(stderr,
-		"Call to deprecated function duh_sigrenderer_set_callback(). The callback\n"
-		"was not installed. See dumb/docs/deprec.txt for how to fix this.\n");*/
-}
-
-
-
-void duh_sigrenderer_set_analyser_callback(
-	DUH_SIGRENDERER *sigrenderer,
-	DUH_SIGRENDERER_ANALYSER_CALLBACK callback, void *data
-)
-{
-	(void)sigrenderer;
-	(void)callback;
-	(void)data;
-	fprintf(stderr,
-		"Call to deprecated function duh_sigrenderer_set_analyser_callback(). The\n"
-		"callback was not installed. See dumb/docs/deprec.txt for how to fix this.\n");
-}
-
-
-
 void duh_sigrenderer_set_sample_analyser_callback(
 	DUH_SIGRENDERER *sigrenderer,
 	DUH_SIGRENDERER_SAMPLE_ANALYSER_CALLBACK callback, void *data
@@ -205,56 +174,6 @@ long duh_sigrenderer_generate_samples(
 		sigrenderer->subpos = (int)t & 65535;
 	}
 
-	return rendered;
-}
-
-
-
-/* DEPRECATED */
-long duh_sigrenderer_get_samples(
-	DUH_SIGRENDERER *sigrenderer,
-	float volume, float delta,
-	long size, sample_t **samples
-)
-{
-	sample_t **s;
-	long rendered;
-	long i;
-	int j;
-	if (!samples) return duh_sigrenderer_generate_samples(sigrenderer, volume, delta, size, NULL);
-	s = allocate_sample_buffer(sigrenderer->n_channels, size);
-	if (!s) return 0;
-	dumb_silence(s[0], sigrenderer->n_channels * size);
-	rendered = duh_sigrenderer_generate_samples(sigrenderer, volume, delta, size, s);
-	for (j = 0; j < sigrenderer->n_channels; j++)
-		for (i = 0; i < rendered; i++)
-			samples[j][i] += s[0][i*sigrenderer->n_channels+j];
-	destroy_sample_buffer(s);
-	return rendered;
-}
-
-
-
-/* DEPRECATED */
-long duh_render_signal(
-	DUH_SIGRENDERER *sigrenderer,
-	float volume, float delta,
-	long size, sample_t **samples
-)
-{
-	sample_t **s;
-	long rendered;
-	long i;
-	int j;
-	if (!samples) return duh_sigrenderer_generate_samples(sigrenderer, volume, delta, size, NULL);
-	s = allocate_sample_buffer(sigrenderer->n_channels, size);
-	if (!s) return 0;
-	dumb_silence(s[0], sigrenderer->n_channels * size);
-	rendered = duh_sigrenderer_generate_samples(sigrenderer, volume, delta, size, s);
-	for (j = 0; j < sigrenderer->n_channels; j++)
-		for (i = 0; i < rendered; i++)
-			samples[j][i] += s[0][i*sigrenderer->n_channels+j] >> 8;
-	destroy_sample_buffer(s);
 	return rendered;
 }
 

--- a/src/helpers/sampbuf.c
+++ b/src/helpers/sampbuf.c
@@ -22,23 +22,6 @@
 
 
 
-/* DEPRECATED */
-sample_t **create_sample_buffer(int n_channels, long length)
-{
-	int i;
-	sample_t **samples = malloc(n_channels * sizeof(*samples));
-	if (!samples) return NULL;
-	samples[0] = malloc(n_channels * length * sizeof(*samples[0]));
-	if (!samples[0]) {
-		free(samples);
-		return NULL;
-	}
-	for (i = 1; i < n_channels; i++) samples[i] = samples[i-1] + length;
-	return samples;
-}
-
-
-
 sample_t **allocate_sample_buffer(int n_channels, long length)
 {
 	int i;


### PR DESCRIPTION
Remove the deprecations except for `duh_render` according to the discussion in #54. Remove the date constants in the header; since 2002, we were told to use `DUMB_MAJOR_VERSION` etc. instead. The date constants are yet another thing that can go out of date.

Everybody, feel free to disagree or push your own commits instead.

I've tested these commits in a freshly-built DUMB via Allegro 5 sample program, and everything builds nicely and plays the music as it should.

~~I've increase the header hardcoded version number to 2.0.0~~, but don't tag yet -- @Rondom would like to change the API for 64-bit file offsets. Waiting until we're all happy before I touch the hardcoded version number.