### PR TITLE
fix #56: initialize volr in all branches

### DIFF
--- a/src/helpers/resample.inc
+++ b/src/helpers/resample.inc
@@ -126,6 +126,7 @@ DUMB_RESAMPLER *dumb_start_resampler(SRCTYPE *src, int src_channels, long pos, l
 		if ( volr == volt ) volume = NULL; \
 	} else { \
 		vol = 0; \
+		volr = 0; \
 		vold = 0; \
 		volt = 0; \
 		volm = 0; \
@@ -187,6 +188,7 @@ DUMB_RESAMPLER *dumb_start_resampler(SRCTYPE *src, int src_channels, long pos, l
 		if ( lvolr == lvolt ) volume_left = NULL; \
 	} else { \
 		lvol = 0; \
+		lvolr = 0; \
 		lvold = 0; \
 		lvolt = 0; \
 		lvolm = 0; \
@@ -200,6 +202,7 @@ DUMB_RESAMPLER *dumb_start_resampler(SRCTYPE *src, int src_channels, long pos, l
 		if ( rvolr == rvolt ) volume_right = NULL; \
 	} else { \
 		rvol = 0; \
+		rvolr = 0; \
 		rvold = 0; \
 		rvolt = 0; \
 		rvolm = 0; \


### PR DESCRIPTION
This fixes 3 compiler warnings from gcc 7.2.0 of the form:

In file included from src/helpers/resample.c:162:0:
src/helpers/resamp3.inc: In function ‘dumb_resample_1_1’:
src/helpers/resample.inc:134:72: warning:
‘volr’ may be used uninitialized in this function [-Wmaybe-uninitialized]