### PR TITLE
getnc returns signed, bump to 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(libdumb C)
 include(GNUInstallDirs)
 
 # Bump major (== soversion) on API breakages
-set(DUMB_VERSION_MAJOR 1)
+set(DUMB_VERSION_MAJOR 2)
 set(DUMB_VERSION_MINOR 0)
 set(DUMB_VERSION ${DUMB_VERSION_MAJOR}.${DUMB_VERSION_MINOR})
 

--- a/include/dumb.h
+++ b/include/dumb.h
@@ -143,19 +143,44 @@ typedef ssize_t dumb_ssize_t;
 #endif
 
 /*
+ * DUMB provides an abstraction over files, to work with memory-mapped files,
+ * files on disk, files read into memory by other libraries in their own
+ * custom formats, ...
+ *
  * Register your own file-handling functions as callbacks via this struct.
- * See DUMBFILE_SYSTEM.md in the project root directory for the spec.
  * DUMB 2.0 doesn't use long anymore. The 64-bit dumb_*_t are defined above.
+ *
+ * See DUMBFILE_SYSTEM.md in project's root for a complete spec.
  */
 typedef struct DUMBFILE_SYSTEM
 {
+	/* open */
+	/* Open filename. Returned file may be of any custom type. */
 	void *(*open)(const char *filename);
+
+	/* skip */
+	/* Ignore the next n bytes in file f. Returns 0 on succes, -1 on error. */
 	int (*skip)(void *f, dumb_off_t n);
+
+	/* getc */
+	/* Read the next byte. Returns byte as unsigned, or -1 on error. */
 	int (*getc)(void *f);
+
+	/* getnc */
+	/* Read n bytes into buffer ptr. Returns number of bytes read or -1. */
 	dumb_ssize_t (*getnc)(char *ptr, size_t n, void *f);
+
+	/* close */
+	/* Called when DUMB is done with the file. User code may do anything. */
 	void (*close)(void *f);
-    int (*seek)(void *f, dumb_off_t offset);
-    dumb_off_t (*get_size)(void *f);
+
+	/* seek */
+	/* Jump to offset in bytes from beginning. Returns 0 if OK, -1 on error. */
+	int (*seek)(void *f, dumb_off_t offset);
+
+	/* get_size */
+	/* Returns the size in bytes of the file. */
+	dumb_off_t (*get_size)(void *f);
 }
 DUMBFILE_SYSTEM;
 

--- a/include/dumb.h
+++ b/include/dumb.h
@@ -35,15 +35,16 @@
 	extern "C" {
 #endif
 
-
-#define DUMB_MAJOR_VERSION    1
+/*
+ * When you bump major, minor, or patch, bump both the number and the string.
+ * When you bump major or minor version, bump them in CMakeLists.txt, too.
+ */
+#define DUMB_MAJOR_VERSION    2
 #define DUMB_MINOR_VERSION    0
 #define DUMB_REVISION_VERSION 0
+#define DUMB_VERSION_STR "2.0.0"
 
 #define DUMB_VERSION (DUMB_MAJOR_VERSION*10000 + DUMB_MINOR_VERSION*100 + DUMB_REVISION_VERSION)
-
-#define DUMB_VERSION_STR "1.0.0"
-
 #define DUMB_NAME "DUMB v" DUMB_VERSION_STR
 
 

--- a/include/dumb.h
+++ b/include/dumb.h
@@ -129,13 +129,30 @@ void dumb_exit(void);
 	};
 #endif
 
+/*
+ * ssize_t is defined in POSIX to hold either a size_t or an error.
+ * We will use dumb_ssize_t on all platforms for (either size_t or error) in
+ * all getnc-type functions. See DUMBFILE_SYSTEM.md for that function's spec.
+ */
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T dumb_ssize_t;
+#else
+#include <sys/types.h>
+typedef ssize_t dumb_ssize_t;
+#endif
 
+/*
+ * Register your own file-handling functions as callbacks via this struct.
+ * See DUMBFILE_SYSTEM.md in the project root directory for the spec.
+ * DUMB 2.0 doesn't use long anymore. The 64-bit dumb_*_t are defined above.
+ */
 typedef struct DUMBFILE_SYSTEM
 {
 	void *(*open)(const char *filename);
 	int (*skip)(void *f, dumb_off_t n);
 	int (*getc)(void *f);
-	size_t (*getnc)(char *ptr, size_t n, void *f);
+	dumb_ssize_t (*getnc)(char *ptr, size_t n, void *f);
 	void (*close)(void *f);
     int (*seek)(void *f, dumb_off_t offset);
     dumb_off_t (*get_size)(void *f);
@@ -171,7 +188,7 @@ long dumbfile_mgetl(DUMBFILE *f);
 unsigned long dumbfile_cgetul(DUMBFILE *f);
 signed long dumbfile_cgetsl(DUMBFILE *f);
 
-size_t dumbfile_getnc(char *ptr, size_t n, DUMBFILE *f);
+dumb_ssize_t dumbfile_getnc(char *ptr, size_t n, DUMBFILE *f);
 
 int dumbfile_error(DUMBFILE *f);
 int dumbfile_close(DUMBFILE *f);

--- a/include/internal/it.h
+++ b/include/internal/it.h
@@ -385,7 +385,7 @@ struct IT_ENTRY
 struct IT_PATTERN
 {
 	int n_rows;
-	size_t n_entries;
+	int n_entries;
 	IT_ENTRY *entry;
 };
 
@@ -724,7 +724,7 @@ struct DUMB_IT_SIGRENDERER
 	void * played;
 
 	/*
-	   Loop indicator for internal processes, may also be useful for external processes 
+	   Loop indicator for internal processes, may also be useful for external processes
 	   0 - Not looped
 	   1 - Looped
 	  -1 - Continued past loop
@@ -743,7 +743,7 @@ struct DUMB_IT_SIGRENDERER
 	int gvz_sub_time;
 
     int ramp_style;
-    
+
 	//int max_output;
 };
 

--- a/src/core/dumbfile.c
+++ b/src/core/dumbfile.c
@@ -340,9 +340,9 @@ signed long dumbfile_cgetsl(DUMBFILE *f)
 
 
 
-size_t dumbfile_getnc(char *ptr, size_t n, DUMBFILE *f)
+dumb_ssize_t dumbfile_getnc(char *ptr, size_t n, DUMBFILE *f)
 {
-	long rv;
+	dumb_ssize_t rv;
 
 	ASSERT(f);
 	ASSERT(n >= 0);
@@ -352,12 +352,12 @@ size_t dumbfile_getnc(char *ptr, size_t n, DUMBFILE *f)
 
 	if (f->dfs->getnc) {
 		rv = (*f->dfs->getnc)(ptr, n, f->file);
-		if (rv < n) {
+		if (rv < (dumb_ssize_t) n) {
 			f->pos = -1;
 			return MAX(rv, 0);
 		}
 	} else {
-		for (rv = 0; rv < n; rv++) {
+		for (rv = 0; rv < (dumb_ssize_t) n; rv++) {
 			int c = (*f->dfs->getc)(f->file);
 			if (c < 0) {
 				f->pos = -1;

--- a/src/helpers/memfile.c
+++ b/src/helpers/memfile.c
@@ -37,7 +37,7 @@ struct MEMFILE
 static int dumb_memfile_skip(void *f, dumb_off_t n)
 {
 	MEMFILE *m = f;
-	if (n > m->left) return -1;
+	if (n > (dumb_off_t)m->left) return -1;
 	m->ptr += n;
 	m->left -= n;
 	return 0;
@@ -55,7 +55,7 @@ static int dumb_memfile_getc(void *f)
 
 
 
-static size_t dumb_memfile_getnc(char *ptr, size_t n, void *f)
+static dumb_ssize_t dumb_memfile_getnc(char *ptr, size_t n, void *f)
 {
 	MEMFILE *m = f;
 	if (n > m->left) n = m->left;

--- a/src/helpers/stdfile.c
+++ b/src/helpers/stdfile.c
@@ -70,7 +70,7 @@ static int dumb_stdfile_getc(void *f)
 
 
 
-static size_t dumb_stdfile_getnc(char *ptr, size_t n, void *f)
+static dumb_ssize_t dumb_stdfile_getnc(char *ptr, size_t n, void *f)
 {
     dumb_stdfile * file = ( dumb_stdfile * ) f;
     return fread(ptr, 1, n, file->file);

--- a/src/it/readam.c
+++ b/src/it/readam.c
@@ -267,7 +267,7 @@ static DUMB_IT_SIGDATA *it_riff_amff_load_sigdata( DUMBFILE * f, struct riff * s
 	DUMB_IT_SIGDATA *sigdata;
 
     int n, found;
-    size_t o, p;
+    int o, p;
 
 	if ( ! stream ) goto error;
 
@@ -301,7 +301,7 @@ static DUMB_IT_SIGDATA *it_riff_amff_load_sigdata( DUMBFILE * f, struct riff * s
         case DUMB_ID( 'P', 'A', 'T', 'T' ):
             if ( dumbfile_seek( f, c->offset, DFS_SEEK_SET ) ) goto error_sd;
             o = dumbfile_getc( f );
-            if ( o >= sigdata->n_patterns ) sigdata->n_patterns = (int)(o + 1);
+            if ( o >= sigdata->n_patterns ) sigdata->n_patterns = (o + 1);
             o = dumbfile_igetl( f );
             if ( (unsigned)o + 5 > c->size ) goto error_sd;
 			break;
@@ -468,7 +468,7 @@ static DUMB_IT_SIGDATA *it_riff_am_load_sigdata( DUMBFILE * f, struct riff * str
 	DUMB_IT_SIGDATA *sigdata;
 
 	int n, found;
-    size_t o, p;
+    int o, p;
 
     if ( ! f || ! stream ) goto error;
 

--- a/src/it/readpsm.c
+++ b/src/it/readpsm.c
@@ -59,7 +59,7 @@ typedef struct _PSMEVENT
 static int it_psm_process_sample(IT_SAMPLE * sample, const unsigned char * data, size_t len, int id, int version) {
 	int flags;
 	int insno;
-	int length;
+	size_t length;
 	int loopstart;
 	int loopend;
 	int panpos;
@@ -100,7 +100,7 @@ static int it_psm_process_sample(IT_SAMPLE * sample, const unsigned char * data,
 		sample->flags &= ~IT_SAMPLE_EXISTS;
 		return 0;
 	}
-	
+
 	if ((length > len - 0x60) || ((flags & 0x7F) != 0)) return -1;
 
 	sample->flags = IT_SAMPLE_EXISTS;
@@ -143,7 +143,8 @@ static int it_psm_process_sample(IT_SAMPLE * sample, const unsigned char * data,
 }
 
 static int it_psm_process_pattern(IT_PATTERN * pattern, const unsigned char * data, size_t len, int speed, int bpm, const unsigned char * pan, const int * vol, int version) {
-	int length, nrows, row, rowlen, pos;
+	size_t length, pos, rowlen;
+	int nrows, row;
 	unsigned flags, chan;
 	IT_ENTRY * entry;
 
@@ -474,7 +475,7 @@ static DUMB_IT_SIGDATA *it_psm_load_sigdata(DUMBFILE *f, int * ver, int subsong)
 
 	unsigned char * ptr;
 
-	size_t n, length;
+	int n, length;
     int o;
 
 	int found;
@@ -519,7 +520,7 @@ static DUMB_IT_SIGDATA *it_psm_load_sigdata(DUMBFILE *f, int * ver, int subsong)
 	}
 
 	if (!n_chunks) goto error_fc;
-				
+
 	sigdata = malloc(sizeof(*sigdata));
 	if (!sigdata) goto error_fc;
 
@@ -814,7 +815,7 @@ static DUMB_IT_SIGDATA *it_psm_load_sigdata(DUMBFILE *f, int * ver, int subsong)
 							if (it_psm_process_pattern(&sigdata->pattern[n_patterns], ptr, length, speed, bpm, pan, vol, found)) goto error_ev;
 							if (first_pattern_line < 0) {
 								first_pattern_line = n;
-								first_pattern = (int)o;
+								first_pattern = o;
 							}
 							e->data[0] = n_patterns;
 							e->data[1] = n_patterns >> 8;
@@ -827,7 +828,7 @@ static DUMB_IT_SIGDATA *it_psm_load_sigdata(DUMBFILE *f, int * ver, int subsong)
 							if (it_psm_process_pattern(&sigdata->pattern[n_patterns], ptr, length, speed, bpm, pan, vol, found)) goto error_ev;
 							if (first_pattern_line < 0) {
 								first_pattern_line = n;
-								first_pattern = (int)o;
+								first_pattern = o;
 							}
 							e->data[0] = n_patterns;
 							e->data[1] = n_patterns >> 8;
@@ -1078,7 +1079,7 @@ static int it_pattern_compare(const IT_PATTERN * p1, const IT_PATTERN * p2) {
 
 	if (p1 == p2) return 1;
 	if (p1->n_entries != p2->n_entries) return 0;
-	
+
 	e1 = p1->entry; end = e1 + p1->n_entries;
 	e2 = p2->entry;
 
@@ -1196,7 +1197,7 @@ int dumb_get_psm_subsong_count(DUMBFILE *f) {
 	size_t length;
     int subsongs;
 	long l;
-	
+
 	if (dumbfile_mgetl(f) != DUMB_ID('P','S','M',' ')) return 0;
 
 	length = dumbfile_igetl(f);
@@ -1222,8 +1223,8 @@ int dumb_get_psm_subsong_count(DUMBFILE *f) {
 /* Eww */
 int pattcmp( const unsigned char * a, const unsigned char * b, size_t l )
 {
-    int i;
-    unsigned long j, na, nb;
+    size_t i, j;
+    unsigned long na, nb;
 	char * p;
 
 	na = nb = 0;
@@ -1261,7 +1262,7 @@ int pattcmp( const unsigned char * a, const unsigned char * b, size_t l )
 	i = memcmp( a, b, j );
 	if ( i ) return i;
 
-	return (int)(na - nb);
+	return (int)((long)na) - ((long)nb);
 }
 
 

--- a/src/it/readptm.c
+++ b/src/it/readptm.c
@@ -216,7 +216,7 @@ static int it_ptm_read_pattern(IT_PATTERN *pattern, DUMBFILE *f, unsigned char *
 		/* Great. We ran out of data, but there should be data for more rows.
 		 * Fill the rest with null data...
 		 */
-		if (buflen >= length && pattern->n_rows < 64)
+		if (buflen >= (dumb_ssize_t) length && pattern->n_rows < 64)
 		{
 			while (pattern->n_rows < 64)
 			{

--- a/src/it/readxm.c
+++ b/src/it/readxm.c
@@ -419,12 +419,12 @@ static int limit_xm_getc(void *f)
 
 
 
-static size_t limit_xm_getnc(char *ptr, size_t n, void *f)
+static dumb_ssize_t limit_xm_getnc(char *ptr, size_t n, void *f)
 {
 	LIMITED_XM *lx = f;
-	long left;
+	dumb_ssize_t left;
 	left = lx->allocated - lx->ptr;
-	if (n > left) {
+	if ((dumb_ssize_t) n > left) {
 		if (left > 0) {
 			memcpy( ptr, lx->buffered + lx->ptr, left );
 			memset( ptr + left, 0, n - left );


### PR DESCRIPTION
getnc returns `dumb_ssize_t` instead of `size_t`. This is necessary because getnc returns -1 on error. Spec updated with the new function signatures.

Fixed resulting comparisons between signed and unsigned that gcc 7.2 shows when we compile with -Wall -Wextra -pedantic. (I have not compiled with -Wconversion to find implicit integer coercion from assigning to narrower types, that would find far too many intended coercions in the music rendering.)

@Rondom has already looked over this and agrees with the header.

@katajakasa, you've also been active recently. Please take a look over the header: Did we do weird things that should be different in 2.0?

---

This bumps the **API to 2.0.0**.

If you don't want this yet, merge everything except for the final commit. Even if everybody agrees, let's wait 1-2 days, only then tag as 2.0.