### PR TITLE
fix internal getnc to return dumb_ssize_t

### DIFF
--- a/DUMBFILE_SYSTEM.md
+++ b/DUMBFILE_SYSTEM.md
@@ -147,7 +147,7 @@ Returns as `dumb_ssize_t`:
 * the number of bytes successfully read, if it was possible to read at least
 one byte.
 
-* `-1` on error.
+* `-1` on error, when it was not possible to read even a single byte.
 
 This function shall bytes from the file `f` and store them in sequence in the
 buffer beginning at `ptr`. It shall read fewer than `n` bytes if end of file

--- a/src/allegro/packfile.c
+++ b/src/allegro/packfile.c
@@ -59,12 +59,15 @@ static int dumb_packfile_getc(void *f) {
     return c;
 }
 
-static size_t dumb_packfile_getnc(char *ptr, size_t n, void *f) {
+static dumb_ssize_t dumb_packfile_getnc(char *ptr, size_t n, void *f) {
     dumb_packfile *file = (dumb_packfile *)f;
-    int nr = pack_fread(ptr, n, file->p);
-    if (nr > 0)
+    errno = 0;
+    long nr = pack_fread(ptr, n, file->p);
+    if (nr > 0) {
         file->pos += nr;
-    return nr;
+        return nr;
+    }
+    return errno != 0 ? -1 : 0;
 }
 
 static void dumb_packfile_close(void *f) {


### PR DESCRIPTION
Return type should match what we declare in dumb.h.
Temporary variable should be long, because A4 returns a long here.