### PR TITLE
Fix pkg-config Linking

### DIFF
--- a/pkg-config.pc.in
+++ b/pkg-config.pc.in
@@ -7,6 +7,6 @@ Name: DUMB
 Description: DUMB is a module audio renderer library. 
 Version: @DUMB_VERSION@
 URL: https://github.com/kode54/dumb/
-Libs: -L${libdir} -l@PROJECT_NAME@
+Libs: -L${libdir} -ldumb
 Libs.private: -lm
 Cflags: -I${includedir} 


### PR DESCRIPTION
As it stands `-l@PROJECT_NAME@` causes linking to fail when using the pkg-config because it resolves to `-llibdumb` where it should be just `-ldumb` (because the l means lib).