### PR TITLE
Fix usage of pack_fseek in dumb_packfile_skip

### DIFF
--- a/src/allegro/packfile.c
+++ b/src/allegro/packfile.c
@@ -48,7 +48,7 @@ static void *dumb_packfile_open(const char *filename) {
 static int dumb_packfile_skip(void *f, dumb_off_t n) {
     dumb_packfile *file = (dumb_packfile *)f;
     file->pos += n;
-    return pack_fseek(file->p, file->pos);
+    return pack_fseek(file->p, n);
 }
 
 static int dumb_packfile_getc(void *f) {


### PR DESCRIPTION
According to the Allegro 4 docs, the second argument to [pack_fseek](https://www.allegro.cc/manual/4/api/file-and-compression-routines/pack_fseek) denotes a relative offset, but dumb assumes it is an absolute offset. This resulted in a bug where music files would not load: for example, in `it_xm_load_sigdata` the call to `dumbfile_skip` would mess up the file handle and result in the subsequent version check seeing garbage data.

There is another faulty usage of `pack_fseek` in this file from `dumb_packfile_seek`, however I don't see a way to resolve it as there is no way to jump to an arbitrary position in an allegro packfile. Besides, it seems unused, so probably best to delete it.
